### PR TITLE
perf: load 12MB prefecture GeoJSON at runtime

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,10 +34,11 @@
 - **`PlacesService`는 DOM에 부착하지 않은 `document.createElement("div")` 로 생성한다** (`useRandomPlace.ts`). 과거에는 `StreetView`가 만든 `google.maps.Map` 인스턴스를 `mapAtom`으로 공유했지만 — Dynamic Map 과금 유발 — 생성자 시그니처가 `HTMLDivElement | Map` 이라 div만으로 충분하다. jotai / `src/atom.ts` 는 제거됨. 다시 Map 인스턴스를 넘기는 방향으로 되돌리지 말 것.
 - **Google Maps 스크립트 로딩이 비동기라 앱 마운트 시 `google` 전역이 없을 수 있다.** `StreetView.tsx`는 `requestIdleCallback` (+ Safari 폴리필 `src/util/requestIdleCallbackSafari.js`) 로 초기화를 미루고, `useRandomPlace`는 `typeof google !== "undefined" && google.maps?.places` 가드 + `setTimeout` 폴링으로 `PlacesService` 생성을 지연한다. 두 순서 의존성을 깨지 말 것.
 - **`isLoading` / `location` 소유권은 `useRandomPlace` 훅에 있다.** `App`이 훅을 호출해서 Go! 버튼과 `<StreetView location={...} />`로 분배한다. `StreetView`는 더 이상 훅을 호출하지 않으며, 로딩 상태를 prop으로 받지 않는다 — 이 단방향 흐름을 유지하라.
+- **`japan.json` (12 MB, 47 prefecture `FeatureCollection`) 은 JS 번들에 인라인되지 않고 런타임에 `fetch("/japan.json")` 으로 로드한다.** `useJapanGeoJson` 훅이 모듈 스코프 Promise 캐시로 단일 fetch를 보장한다. `App` 은 `isLoaded` 로 prefecture `<select>` 와 Go! 버튼을 게이트하고, `useRandomPlace` 는 `data` 가 도착할 때까지 `generateBaseLocation` 을 no-op 처리한다. 다시 `import "./asset/japan.json"` 으로 되돌리면 번들이 12 MB로 부풀어 초기 로드가 망가진다.
 
 ## 도메인 상수
 
-- `src/asset/japan.json` — 47개 도도부현 `FeatureCollection`. 이름 키는 `properties.nam` (예: `"Tokyo"`).
+- `public/japan.json` — 47개 도도부현 `FeatureCollection`. 이름 키는 `properties.nam` (예: `"Tokyo"`). 정적 에셋으로 서빙되며 `public/_headers` 가 `Cache-Control: public, max-age=86400` 를 설정한다 (파일명에 해시가 없어 `immutable` 금지, 24시간 한정). 파일 내용을 바꿀 땐 캐시 TTL 지난 뒤에야 클라이언트가 갱신된다는 점을 기억할 것.
 - `PlaceType = "convenience_store" | "train_station" | "starbucks"`. 스타벅스만 `textSearch(query: "Starbucks Coffee")`, 나머지는 `nearbySearch(type)` 로 분기.
 - 검색 반경 시퀀스: `[50, 500, 5000]` (m). 3회 재시도 후 좌표 재생성.
 - `index === -1` 은 "전국 무작위" 를 의미한다.
@@ -45,6 +46,5 @@
 ## 현존 기술부채 (건드릴 때 주의)
 
 - `useRandomPlace.ts` — GeoJSON feature 접근에 `@ts-ignore` 가 아직 남아있다. `d3.ExtendedFeature` 로 좁히면 제거 가능.
-- `App.tsx` — GeoJSON feature 접근을 앱 전용 `PrefectureFeature` 로 좁혀두었다. 공용 GeoJSON 타입으로 정리 가능.
 - `useRandomPlace.ts` 전반에 `baseLoaction` 오타. 리네임 시 전수 치환.
 - `StreetView.tsx` — `StreetViewPanorama` 는 초기 위치 없이 생성하고, 이후 `location` effect가 `setPosition` / POV 보정을 담당한다.

--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,2 @@
+/japan.json
+  Cache-Control: public, max-age=86400

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,34 +2,31 @@ import { useEffect, useState } from "react";
 import { StreetView } from "./StreetView";
 import { PLACE_LABEL, PlaceType } from "./type";
 import { useRandomPlace } from "./useRandomPlace";
-import jpGeoJson from "./asset/japan.json";
-
-type PrefectureFeature = {
-  properties: {
-    nam: string;
-  };
-};
-
-const prefectures = jpGeoJson.features as PrefectureFeature[];
+import { useJapanGeoJson } from "./useJapanGeoJson";
 
 function App() {
   const [placeType, setPlaceType] = useState<PlaceType>("convenience_store");
   const [selected, setSelected] = useState("All Prefecture");
   const [index, setIndex] = useState(-1);
 
+  const { data: jpGeoJson, isLoaded } = useJapanGeoJson();
+
   useEffect(() => {
+    if (!jpGeoJson) return;
     if (selected === "All Prefecture") {
       setIndex(-1);
       return;
     }
 
-    const newIndex = prefectures.findIndex(
-      ({ properties }) => properties.nam === selected
+    const newIndex = jpGeoJson.features.findIndex(
+      (f) => f.properties?.nam === selected
     );
     setIndex(newIndex);
-  }, [selected]);
+  }, [selected, jpGeoJson]);
 
   const { location, isLoading, refresh } = useRandomPlace(placeType, index);
+
+  const disabled = !isLoaded || isLoading;
 
   return (
     <div className="flex flex-col h-[100vh]">
@@ -55,22 +52,31 @@ function App() {
             value={selected}
             onChange={(e) => setSelected(e.target.value)}
             className="text-black"
+            disabled={!isLoaded}
           >
             <option value="All Prefecture">All Prefecture</option>
-            {prefectures.map(({ properties }) => (
-              <option value={properties.nam} key={properties.nam}>
-                {properties.nam}
-              </option>
-            ))}
+            {jpGeoJson?.features.map((f) => {
+              const name = f.properties?.nam as string | undefined;
+              if (!name) return null;
+              return (
+                <option value={name} key={name}>
+                  {name}
+                </option>
+              );
+            })}
           </select>
           <button
             className={`${
-              isLoading ? "bg-gray-300" : "bg-green-500"
+              disabled ? "bg-gray-300" : "bg-green-500"
             } rounded px-[12px] py-[2px]`}
             onClick={refresh}
-            disabled={isLoading}
+            disabled={disabled}
           >
-            {isLoading ? "Loading..." : "➡️ Go!"}
+            {!isLoaded
+              ? "Loading map data..."
+              : isLoading
+              ? "Loading..."
+              : "➡️ Go!"}
           </button>
         </div>
       </div>

--- a/src/useJapanGeoJson.ts
+++ b/src/useJapanGeoJson.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react";
+import type { FeatureCollection } from "geojson";
+
+// Module-scoped promise cache: ensures a single fetch across all hook callers
+// within the SPA lifetime. React strict-mode double-invocation also reuses it.
+let cache: Promise<FeatureCollection> | undefined;
+
+function load(): Promise<FeatureCollection> {
+  if (!cache) {
+    cache = fetch("/japan.json").then((res) => {
+      if (!res.ok) {
+        cache = undefined;
+        throw new Error(`Failed to load japan.json: ${res.status}`);
+      }
+      return res.json() as Promise<FeatureCollection>;
+    });
+  }
+  return cache;
+}
+
+export function useJapanGeoJson() {
+  const [data, setData] = useState<FeatureCollection | undefined>();
+
+  useEffect(() => {
+    let cancelled = false;
+    load()
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        // Leaving data undefined keeps the UI in loading state; retry on next mount.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { data, isLoaded: !!data };
+}

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import * as d3 from "d3";
-import jpGeoJson from "./asset/japan.json";
 import { PlaceType, Location } from "./type";
 import { sleep } from "./util/sleep";
+import { useJapanGeoJson } from "./useJapanGeoJson";
 
 // https://observablehq.com/@jeffreymorganio/random-coordinates-within-a-country
 function randomBoundingBoxCoordinates(boundingBox: number[][]) {
@@ -27,6 +27,7 @@ function randomFeatureCoordinates(feature: d3.ExtendedFeature) {
 }
 
 export function useRandomPlace(placeType: PlaceType, index: number) {
+  const { data: jpGeoJson } = useJapanGeoJson();
   const [baseLoaction, setBaseLocation] = useState<Location | undefined>();
   const [storeLocation, setStoreLocation] = useState<Location | undefined>();
   const serviceRef = useRef<google.maps.places.PlacesService | null>(null);
@@ -52,14 +53,17 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
 
   const generateBaseLocation = useCallback(
     async (requestId = requestIdRef.current) => {
-      const [lat, lng] = randomFeatureCoordinates(
-        // eslint-disable-next-line
-        // @ts-ignore
+      if (!jpGeoJson) return;
+
+      const feature =
         jpGeoJson.features[
           index !== -1
             ? index
             : Math.floor(Math.random() * jpGeoJson.features.length)
-        ] as d3.ExtendedFeature
+        ];
+
+      const [lat, lng] = randomFeatureCoordinates(
+        feature as d3.ExtendedFeature
       )().reverse();
 
       if (requestIdRef.current !== requestId) {
@@ -68,7 +72,7 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
 
       setBaseLocation({ lat, lng });
     },
-    [index]
+    [index, jpGeoJson]
   );
 
   const searchNearBy = useCallback(


### PR DESCRIPTION
## Summary

- Move `src/asset/japan.json` → `public/japan.json` so it is served as a static asset instead of inlined into the JS bundle
- Add `useJapanGeoJson` hook: module-scoped Promise cache, single fetch across the SPA lifetime
- `App` gates the prefecture `<select>` and Go! button on `isLoaded` (shows `Loading map data...` until fetch resolves)
- `useRandomPlace` also consumes the hook; `generateBaseLocation` no-ops until `jpGeoJson` is available, then the existing effect cascade kicks in
- `public/_headers` sets `Cache-Control: public, max-age=86400` for `/japan.json` (24h; no hash in filename → no `immutable`)

> Based on `fix/p0-pr1` — merge that first. If it merges to `main` before this PR, just rebase.

## Evidence

### Static build (bundle separation)

```
# Bundle size before/after (this PR's build)
$ du -h dist/assets/*.js dist/japan.json
 157K dist/assets/index-bc908aae.js
  13M dist/japan.json

# No GeoJSON payload inlined in the JS bundle
$ grep -c "FeatureCollection" dist/assets/*.js
1    # only remaining match is d3-geo internal code ("FeatureCollection:function(e,n){...")

# Imports from src/asset/japan.json removed
$ grep -rn "asset/japan" src
(no matches)

# yarn build ✅    (157 KB JS, 51 KB gzip — down from 3.26 MB)
# yarn lint       4 warnings, all pre-existing in StreetView.tsx (no new warnings)
```

### Runtime (Preview MCP, dev server on `http://localhost:5173`)

`/japan.json` is fetched as a **separate static resource**, not part of the JS bundle:

```js
// performance.getEntriesByType('resource')
{
  url: "http://localhost:5173/japan.json",
  initiatorType: "fetch",       // ← not 'script'
  transferSize: 13050392,       // 12.44 MB, served as static asset
  duration: 32                  // ms
}

// App bundle (no GeoJSON inlined)
App.tsx: 14159 bytes
main.tsx: 2388 bytes
```

Subsequent Go! cycle after fetch resolved — full happy path:

```js
// performance.getEntriesByType('resource') filtered by host
dynamicMap:        0       // maps/vt, StaticMapService — no Dynamic Map billing (B3 preserved)
placesSearch:      3       // PlaceService.FindPlaces — 50m/500m/5000m retry sequence
mapsApi (head):    gen_204, AuthenticationService, PlaceService.FindPlaces ×3,
                   SingleImageSearch, GeoPhotoService.GetMetadata
```

Snapshot confirms:
- `<select>` contains **48 options** (All Prefecture + 47 prefectures including `Kanagawa Ken` at UID 100)
- Go! button reaches `"➡️ Go!"` idle state (not stuck in `Loading map data...`)
- Street View panorama rendered for a real place (`天河大辨財天社（天河神社）`)
- `preview_console_logs --level error` → zero errors

## Notes

- Git tracks `public/japan.json` as a rename of `src/asset/japan.json` (100% similarity) — file history preserved.
- `@types/geojson` is available transitively via `@types/d3-geo`, so no new devDep needed.
- Error path: if fetch fails, `data` stays `undefined` → UI stays in `Loading map data...`. Explicit error surface is tracked as a follow-up (see plan's Follow-up §3).
- `Cache-Control: public, max-age=86400` header only takes effect on Netlify (production) — `vite dev`/`vite preview` do not apply `public/_headers`. Verify via `curl -I` on the Netlify preview deploy.

## Test plan

- [x] Dev server: Network panel shows `/japan.json` as `fetch` initiator with 12.44 MB transfer (verified via Preview MCP)
- [x] Go! button disabled / labeled `Loading map data...` until fetch completes (code path verified; snapshot taken post-load)
- [x] Prefecture dropdown populates with all 47 names (Kanagawa Ken present)
- [x] No regression on convenience_store flow — PlaceService retry cycle (3 requests) + Street View panorama rendered
- [ ] Netlify preview: second load returns `/japan.json` from cache (304 / `memory cache`) — verify after deploy
- [ ] Netlify preview: `curl -I /japan.json` returns `Cache-Control: public, max-age=86400`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
