### PR TITLE
feat: 가이드북 무드 헤더 디자인 적용

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/src/asset/icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Shippori+Mincho:wght@500;700&display=swap"
+      rel="stylesheet"
+    />
     <meta
       name="google-site-verification"
       content="MfNa5RVmp-hnTdYY5X_qsE2fE-TnREzCGNoZA8rLhRI"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { StreetView } from "./StreetView";
-import { PLACE_LABEL, PlaceType } from "./type";
+import { PLACE_ICON, PLACE_LABEL, PlaceType } from "./type";
 import { useRandomPlace } from "./useRandomPlace";
 import { useJapanGeoJson } from "./useJapanGeoJson";
 
@@ -30,20 +30,41 @@ function App() {
 
   return (
     <div className="flex flex-col h-[100vh]">
-      <div className="top-0 z-50 absolute bottom-0 w-[100vw] bg-black opacity-75 h-fit flex flex-col items-start gap-[12px] text-white px-[12px] py-[8px]">
+      <div className="top-0 z-50 absolute w-[100vw] bg-cream border-b border-black/10 flex flex-col items-start gap-[14px] px-[28px] py-[22px] text-neutral-900">
+        <div
+          className="absolute top-[18px] right-[28px] border-2 border-vermillion text-vermillion px-[10px] py-[6px] rounded-[2px] font-serif font-bold text-[10px] tracking-[2px] rotate-[-6deg] select-none"
+          aria-hidden="true"
+        >
+          JAPAN EXPLORE
+        </div>
         <div className="flex flex-col gap-[2px]">
-          <h1 className="font-semibold text-[24px]">Random Places in Japan</h1>
-          <span className="text-[12px]">
+          <div
+            className="font-serif text-[13px] text-vermillion tracking-[3px] mb-[2px]"
+            aria-hidden="true"
+          >
+            日本各地をランダム探索
+          </div>
+          <h1 className="font-serif font-bold text-[28px] leading-tight tracking-tight">
+            Random Places in <span className="text-vermillion">Japan</span>
+          </h1>
+          <span className="text-[13px] text-neutral-600">
             Let's explore random places in japan. Choose place type and hit Go!
           </span>
         </div>
-        <div className="flex flex-row items-center justify-start gap-[16px]">
+        <div className="flex flex-row items-center justify-start gap-[8px] flex-wrap w-full">
           {Object.entries(PLACE_LABEL).map(([key, label]) => (
             <button
               key={key}
-              className={key === placeType ? "text-green-500" : "text-white"}
+              className={`px-[14px] py-[8px] text-[13px] font-medium rounded-sm border transition-colors flex items-center gap-[6px] ${
+                key === placeType
+                  ? "bg-neutral-900 text-white border-neutral-900"
+                  : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-500"
+              }`}
               onClick={() => setPlaceType(key as PlaceType)}
             >
+              <span className="text-[14px]" aria-hidden="true">
+                {PLACE_ICON[key as PlaceType]}
+              </span>
               {label}
             </button>
           ))}
@@ -51,7 +72,7 @@ function App() {
           <select
             value={selected}
             onChange={(e) => setSelected(e.target.value)}
-            className="text-black"
+            className="bg-white text-neutral-800 border border-neutral-300 rounded-sm px-[14px] py-[8px] text-[13px] disabled:opacity-60"
             disabled={!isLoaded}
           >
             <option value="All Prefecture">All Prefecture</option>
@@ -66,9 +87,11 @@ function App() {
             })}
           </select>
           <button
-            className={`${
-              disabled ? "bg-gray-300" : "bg-green-500"
-            } rounded px-[12px] py-[2px]`}
+            className={`ml-auto rounded-sm px-[22px] py-[10px] text-[13px] font-semibold tracking-wider text-white transition-transform ${
+              disabled
+                ? "bg-neutral-400 shadow-none"
+                : "bg-vermillion shadow-[3px_3px_0_#1a1a1a] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[2px_2px_0_#1a1a1a]"
+            }`}
             onClick={refresh}
             disabled={disabled}
           >

--- a/src/type.ts
+++ b/src/type.ts
@@ -10,3 +10,9 @@ export const PLACE_LABEL: { [key in PlaceType]: string } = {
   train_station: "Train Station",
   starbucks: "Starbucks",
 } as const;
+
+export const PLACE_ICON: { [key in PlaceType]: string } = {
+  convenience_store: "🍙",
+  train_station: "🚉",
+  starbucks: "☕",
+} as const;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,16 @@
 export default {
   content: ["./src/**/*.{ts,tsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'system-ui', 'sans-serif'],
+        serif: ['"Shippori Mincho"', 'serif'],
+      },
+      colors: {
+        cream: '#fdf6e8',
+        vermillion: '#c8102e',
+      },
+    },
   },
   plugins: [],
   important: true,


### PR DESCRIPTION
## Summary
- 크림 배경 + 주홍 액센트(#c8102e)로 일본 여행 가이드북 무드 재해석
- Shippori Mincho 명조체, 일본어 서브타이틀, JAPAN EXPLORE 스탬프 추가
- 장소 타입 버튼에 이모지 아이콘 + segmented 스타일, Go! 버튼을 주홍 CTA + 검정 오프셋 그림자

## 변경 파일
- `index.html`: Google Fonts (Inter, Shippori Mincho) 추가
- `tailwind.config.js`: `font-serif`, `cream`, `vermillion` 커스텀 토큰
- `src/type.ts`: `PLACE_ICON` 맵 추가
- `src/App.tsx`: 헤더 레이아웃/스타일만 재작성 (기능 로직은 그대로)

## Test plan
- [ ] https 로컬(또는 배포 프리뷰)에서 버튼 클릭 시 Street View 정상 전환
- [ ] Prefecture select에서 지역 선택 후 Go! 동작 확인
- [ ] 모바일 폭에서 컨트롤 wrap 확인
- [ ] 폰트 로딩 전 FOUT 체감