### PR TITLE
[codex] reduce random place loading latency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,7 @@
 
 코드만 보고는 오해하기 쉬운 지점들:
 
-- **Google Maps API는 `index.html:45`의 `<script>` 태그로 전역 로드된다.** 앱은 `google.maps.*` 전역을 직접 쓴다. `@react-google-maps/api`가 `package.json`에 있지만 실제로는 사용하지 않는다 — 로더로 감싸지 말고 지금 방식을 유지하거나, 바꿀 거면 의존성 제거까지 한 번에 하라.
+- **Google Maps API는 `index.html:45`의 `<script>` 태그로 전역 로드된다.** 앱은 `google.maps.*` 전역을 직접 쓴다. 과거의 `@react-google-maps/api` 의존성은 제거됐다 — 로더로 감싸는 변경을 하려면 전역 로드 방식까지 한 번에 재설계하라.
 - **API 키는 `index.html`에 하드코딩**되어 있고 `randomplacesjapan.netlify.app` 도메인 제한으로 보호된다. 로컬에서 404/Referer 에러가 나면 키가 아니라 도메인 제한 설정을 확인하라.
 - **`PlacesService`는 DOM에 부착하지 않은 `document.createElement("div")` 로 생성한다** (`useRandomPlace.ts`). 과거에는 `StreetView`가 만든 `google.maps.Map` 인스턴스를 `mapAtom`으로 공유했지만 — Dynamic Map 과금 유발 — 생성자 시그니처가 `HTMLDivElement | Map` 이라 div만으로 충분하다. jotai / `src/atom.ts` 는 제거됨. 다시 Map 인스턴스를 넘기는 방향으로 되돌리지 말 것.
 - **Google Maps 스크립트 로딩이 비동기라 앱 마운트 시 `google` 전역이 없을 수 있다.** `StreetView.tsx`는 `requestIdleCallback` (+ Safari 폴리필 `src/util/requestIdleCallbackSafari.js`) 로 초기화를 미루고, `useRandomPlace`는 `typeof google !== "undefined" && google.maps?.places` 가드 + `setTimeout` 폴링으로 `PlacesService` 생성을 지연한다. 두 순서 의존성을 깨지 말 것.
@@ -40,11 +40,9 @@
 
 - `public/japan.json` — 47개 도도부현 `FeatureCollection`. 이름 키는 `properties.nam` (예: `"Tokyo"`). 정적 에셋으로 서빙되며 `public/_headers` 가 `Cache-Control: public, max-age=86400` 를 설정한다 (파일명에 해시가 없어 `immutable` 금지, 24시간 한정). 파일 내용을 바꿀 땐 캐시 TTL 지난 뒤에야 클라이언트가 갱신된다는 점을 기억할 것.
 - `PlaceType = "convenience_store" | "train_station" | "starbucks"`. 스타벅스만 `textSearch(query: "Starbucks Coffee")`, 나머지는 `nearbySearch(type)` 로 분기.
-- 검색 반경 시퀀스: `[50, 500, 5000]` (m). 3회 재시도 후 좌표 재생성.
+- 검색은 랜덤 base point마다 `5000m` 반경으로 한 번 수행한다. `ZERO_RESULTS` 는 대기 없이 다음 base point로 넘기고, `UNKNOWN_ERROR` 만 짧게 재시도한다. 일반 실패마다 `sleep(1000)` 을 넣으면 Go! 버튼 tail latency가 다시 10초대로 늘어난다.
 - `index === -1` 은 "전국 무작위" 를 의미한다.
 
 ## 현존 기술부채 (건드릴 때 주의)
 
-- `useRandomPlace.ts` — GeoJSON feature 접근에 `@ts-ignore` 가 아직 남아있다. `d3.ExtendedFeature` 로 좁히면 제거 가능.
-- `useRandomPlace.ts` 전반에 `baseLoaction` 오타. 리네임 시 전수 치환.
 - `StreetView.tsx` — `StreetViewPanorama` 는 초기 위치 없이 생성하고, 이후 `location` effect가 `setPosition` / POV 보정을 담당한다.

--- a/src/StreetView.tsx
+++ b/src/StreetView.tsx
@@ -39,9 +39,17 @@ export function StreetView({
   }, [onIdle]);
 
   useEffect(() => {
-    if (panorama && location) {
-      panorama.setPosition(location);
+    if (!panorama) {
+      return;
     }
+
+    if (!location) {
+      panorama.setVisible(false);
+      return;
+    }
+
+    panorama.setVisible(true);
+    panorama.setPosition(location);
   }, [location, panorama]);
 
   useEffect(() => {

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -6,6 +6,7 @@ import { useJapanGeoJson } from "./useJapanGeoJson";
 
 const SEARCH_RADIUS_METERS = 5000;
 const MAX_BASE_LOCATION_ATTEMPTS = 8;
+const MAX_SEARCH_ROUNDS = 2;
 const RETRYABLE_STATUS_DELAY_MS = 250;
 const MAX_RETRYABLE_STATUS_RETRIES = 1;
 
@@ -192,43 +193,49 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
         return;
       }
 
-      for (let attempt = 0; attempt < MAX_BASE_LOCATION_ATTEMPTS; attempt += 1) {
-        if (requestIdRef.current !== requestId) {
-          return;
-        }
-
-        const baseLocation = generateBaseLocation();
-        if (!baseLocation) {
-          setIsLoading(false);
-          return;
-        }
-
-        const result = await searchStore(baseLocation, requestId);
-
-        if (requestIdRef.current !== requestId) {
-          return;
-        }
-
-        if (result.type === "stale") {
-          return;
-        }
-
-        if (result.type === "fatal") {
-          setIsLoading(false);
-          return;
-        }
-
-        if (result.type === "found") {
-          const newStoreLocation = result.place.geometry?.location;
-          if (!newStoreLocation) {
-            continue;
+      for (let round = 0; round < MAX_SEARCH_ROUNDS; round += 1) {
+        for (
+          let attempt = 0;
+          attempt < MAX_BASE_LOCATION_ATTEMPTS;
+          attempt += 1
+        ) {
+          if (requestIdRef.current !== requestId) {
+            return;
           }
-          setStoreLocation({
-            lat: newStoreLocation.lat(),
-            lng: newStoreLocation.lng(),
-          });
-          setIsLoading(false);
-          return;
+
+          const baseLocation = generateBaseLocation();
+          if (!baseLocation) {
+            setIsLoading(false);
+            return;
+          }
+
+          const result = await searchStore(baseLocation, requestId);
+
+          if (requestIdRef.current !== requestId) {
+            return;
+          }
+
+          if (result.type === "stale") {
+            return;
+          }
+
+          if (result.type === "fatal") {
+            setIsLoading(false);
+            return;
+          }
+
+          if (result.type === "found") {
+            const newStoreLocation = result.place.geometry?.location;
+            if (!newStoreLocation) {
+              continue;
+            }
+            setStoreLocation({
+              lat: newStoreLocation.lat(),
+              lng: newStoreLocation.lng(),
+            });
+            setIsLoading(false);
+            return;
+          }
         }
       }
 
@@ -236,6 +243,7 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
         return;
       }
 
+      setStoreLocation(undefined);
       setIsLoading(false);
     },
     [generateBaseLocation, isServiceReady, jpGeoJson, searchStore]

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -4,6 +4,20 @@ import { PlaceType, Location } from "./type";
 import { sleep } from "./util/sleep";
 import { useJapanGeoJson } from "./useJapanGeoJson";
 
+const SEARCH_RADIUS_METERS = 5000;
+const MAX_BASE_LOCATION_ATTEMPTS = 8;
+const RETRYABLE_STATUS_DELAY_MS = 250;
+const MAX_RETRYABLE_STATUS_RETRIES = 1;
+
+type PlacesStatus = google.maps.places.PlacesServiceStatus | string;
+
+type PlaceSearchOutcome =
+  | { type: "found"; place: google.maps.places.PlaceResult }
+  | { type: "empty"; status: PlacesStatus }
+  | { type: "retryable"; status: PlacesStatus }
+  | { type: "fatal"; status: PlacesStatus }
+  | { type: "stale" };
+
 // https://observablehq.com/@jeffreymorganio/random-coordinates-within-a-country
 function randomBoundingBoxCoordinates(boundingBox: number[][]) {
   const randomLongitude = d3.randomUniform(
@@ -28,8 +42,9 @@ function randomFeatureCoordinates(feature: d3.ExtendedFeature) {
 
 export function useRandomPlace(placeType: PlaceType, index: number) {
   const { data: jpGeoJson } = useJapanGeoJson();
-  const [baseLoaction, setBaseLocation] = useState<Location | undefined>();
   const [storeLocation, setStoreLocation] = useState<Location | undefined>();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isServiceReady, setIsServiceReady] = useState(false);
   const serviceRef = useRef<google.maps.places.PlacesService | null>(null);
   const requestIdRef = useRef(0);
 
@@ -40,6 +55,7 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
       if (typeof google !== "undefined" && google.maps?.places) {
         const container = document.createElement("div");
         serviceRef.current = new google.maps.places.PlacesService(container);
+        setIsServiceReady(true);
         return;
       }
       setTimeout(tryInit, 100);
@@ -48,183 +64,196 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
     return () => {
       cancelled = true;
       serviceRef.current = null;
+      setIsServiceReady(false);
     };
   }, []);
 
-  const generateBaseLocation = useCallback(
-    async (requestId = requestIdRef.current) => {
-      if (!jpGeoJson) return;
+  const generateBaseLocation = useCallback(() => {
+    if (!jpGeoJson) return undefined;
 
-      const feature =
-        jpGeoJson.features[
-          index !== -1
-            ? index
-            : Math.floor(Math.random() * jpGeoJson.features.length)
-        ];
+    const feature =
+      jpGeoJson.features[
+        index !== -1 ? index : Math.floor(Math.random() * jpGeoJson.features.length)
+      ];
 
-      const [lat, lng] = randomFeatureCoordinates(
-        feature as d3.ExtendedFeature
-      )().reverse();
+    const [lat, lng] = randomFeatureCoordinates(
+      feature as d3.ExtendedFeature
+    )().reverse();
 
-      if (requestIdRef.current !== requestId) {
-        return;
-      }
-
-      setBaseLocation({ lat, lng });
-    },
-    [index, jpGeoJson]
-  );
+    return { lat, lng };
+  }, [index, jpGeoJson]);
 
   const searchNearBy = useCallback(
-    (radius: number, requestId: number) => {
-      if (
-        requestIdRef.current !== requestId ||
-        !baseLoaction ||
-        !serviceRef.current
-      ) {
-        return Promise.resolve(undefined);
+    (location: Location, radius: number, requestId: number) => {
+      if (requestIdRef.current !== requestId || !serviceRef.current) {
+        return Promise.resolve<PlaceSearchOutcome>({ type: "stale" });
       }
 
       const service = serviceRef.current;
 
-      return new Promise<google.maps.places.PlaceResult | undefined>(
-        (resolve) => {
-          const handleResult = (
-            res: google.maps.places.PlaceResult[] | null,
-            status: string
-          ) => {
-            if (requestIdRef.current !== requestId) {
-              resolve(undefined);
-              return;
-            }
-
-            if (status !== "OK" || !res || res.length === 0) {
-              resolve(undefined);
-              return;
-            }
-
-            const randomIndex = Math.floor(Math.random() * res.length);
-
-            resolve(res[randomIndex]);
-          };
-
-          if (placeType === "starbucks") {
-            const textRequest: google.maps.places.TextSearchRequest = {
-              location: baseLoaction,
-              radius,
-              query: "Starbucks Coffee",
-              type: "cafe",
-            };
-
-            service.textSearch(textRequest, handleResult);
+      return new Promise<PlaceSearchOutcome>((resolve) => {
+        const handleResult = (
+          res: google.maps.places.PlaceResult[] | null,
+          status: PlacesStatus
+        ) => {
+          if (requestIdRef.current !== requestId) {
+            resolve({ type: "stale" });
             return;
           }
 
-          const request: google.maps.places.PlaceSearchRequest = {
-            location: baseLoaction,
+          if (status === "OK" && res && res.length > 0) {
+            const randomIndex = Math.floor(Math.random() * res.length);
+            resolve({ type: "found", place: res[randomIndex] });
+            return;
+          }
+
+          if (status === "OK" || status === "ZERO_RESULTS") {
+            resolve({ type: "empty", status });
+            return;
+          }
+
+          if (status === "UNKNOWN_ERROR") {
+            resolve({ type: "retryable", status });
+            return;
+          }
+
+          resolve({ type: "fatal", status });
+        };
+
+        if (placeType === "starbucks") {
+          const textRequest: google.maps.places.TextSearchRequest = {
+            location,
             radius,
-            type: placeType,
+            query: "Starbucks Coffee",
+            type: "cafe",
           };
 
-          service.nearbySearch(request, (res, status) => {
-            handleResult(res, status);
-          });
+          service.textSearch(textRequest, handleResult);
+          return;
         }
-      );
+
+        const request: google.maps.places.PlaceSearchRequest = {
+          location,
+          radius,
+          type: placeType,
+        };
+
+        service.nearbySearch(request, (res, status) => {
+          handleResult(res, status);
+        });
+      });
     },
-    [baseLoaction, placeType]
+    [placeType]
   );
 
   const searchStore = useCallback(
-    async (requestId: number) => {
-      const radii = [50, 500, 5000];
-
-      for (const radius of radii) {
+    async (
+      baseLocation: Location,
+      requestId: number
+    ): Promise<PlaceSearchOutcome> => {
+      for (
+        let retry = 0;
+        retry <= MAX_RETRYABLE_STATUS_RETRIES;
+        retry += 1
+      ) {
         if (requestIdRef.current !== requestId) {
-          return undefined;
+          return { type: "stale" };
         }
 
-        const result = await searchNearBy(radius, requestId);
+        const result = await searchNearBy(
+          baseLocation,
+          SEARCH_RADIUS_METERS,
+          requestId
+        );
+
         if (requestIdRef.current !== requestId) {
-          return undefined;
+          return { type: "stale" };
         }
 
-        if (result) {
+        if (result.type !== "retryable") {
           return result;
         }
 
-        await sleep(1000);
+        if (retry < MAX_RETRYABLE_STATUS_RETRIES) {
+          await sleep(RETRYABLE_STATUS_DELAY_MS);
+        }
       }
 
-      return undefined;
+      return { type: "retryable", status: "UNKNOWN_ERROR" };
     },
     [searchNearBy]
   );
 
-  const refresh = useCallback(() => {
-    requestIdRef.current += 1;
-    setStoreLocation(undefined);
-    setBaseLocation(undefined);
-    generateBaseLocation(requestIdRef.current);
-  }, [generateBaseLocation]);
-
-  const asyncJob = useCallback(
+  const runSearch = useCallback(
     async (requestId: number) => {
-      const maxAttempts = 3;
+      setIsLoading(true);
 
-      for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+      if (!jpGeoJson || !isServiceReady) {
+        return;
+      }
+
+      for (let attempt = 0; attempt < MAX_BASE_LOCATION_ATTEMPTS; attempt += 1) {
         if (requestIdRef.current !== requestId) {
           return;
         }
 
-        const newStore = await searchStore(requestId);
+        const baseLocation = generateBaseLocation();
+        if (!baseLocation) {
+          setIsLoading(false);
+          return;
+        }
+
+        const result = await searchStore(baseLocation, requestId);
 
         if (requestIdRef.current !== requestId) {
           return;
         }
 
-        const newStoreLocation = newStore?.geometry?.location;
+        if (result.type === "stale") {
+          return;
+        }
 
-        if (newStoreLocation) {
+        if (result.type === "fatal") {
+          setIsLoading(false);
+          return;
+        }
+
+        if (result.type === "found") {
+          const newStoreLocation = result.place.geometry?.location;
+          if (!newStoreLocation) {
+            continue;
+          }
           setStoreLocation({
             lat: newStoreLocation.lat(),
             lng: newStoreLocation.lng(),
           });
+          setIsLoading(false);
           return;
         }
-
-        await sleep(1000);
       }
 
       if (requestIdRef.current !== requestId) {
         return;
       }
 
-      refresh();
+      setIsLoading(false);
     },
-    [refresh, searchStore]
+    [generateBaseLocation, isServiceReady, jpGeoJson, searchStore]
   );
 
-  useEffect(() => {
-    if (!storeLocation && !baseLoaction) {
-      generateBaseLocation(requestIdRef.current);
-    }
-  }, [baseLoaction, storeLocation, generateBaseLocation]);
+  const refresh = useCallback(() => {
+    requestIdRef.current += 1;
+    void runSearch(requestIdRef.current);
+  }, [runSearch]);
 
   useEffect(() => {
-    if (baseLoaction && !storeLocation) {
-      const currentRequestId = requestIdRef.current;
-      asyncJob(currentRequestId);
-    }
-  }, [asyncJob, baseLoaction, storeLocation]);
-
-  useEffect(() => {
-    refresh();
-  }, [placeType, index, refresh]);
+    requestIdRef.current += 1;
+    void runSearch(requestIdRef.current);
+  }, [runSearch]);
 
   return {
     location: storeLocation,
-    isLoading: !storeLocation,
+    isLoading,
     refresh,
   };
 }


### PR DESCRIPTION
## Summary

- Replace the legacy Places retry loop that waited `sleep(1000)` after ordinary no-result searches.
- Search each random base point with a single `5000m` radius, then immediately try another base point on `ZERO_RESULTS` / empty `OK`.
- Keep a short retry only for `UNKNOWN_ERROR`, which Google documents as a server error that may succeed when retried.
- Track `isLoading` explicitly instead of deriving it from `!storeLocation`, so a bounded no-result run can return the Go button to idle.
- Update `CLAUDE.md` to document the new search policy and remove stale notes.

## Root Cause

The intermittent long loading was caused by app-side sleeps, not slow individual Google Places responses. The previous flow tried `[50, 500, 5000]` for a random coordinate and slept 1 second after every miss; after three failed search rounds it refreshed and repeated. In baseline measurements, the Places network calls were usually ~100-200ms each, while the Go button stayed loading for 13s, 27s, and 52s because those explicit sleeps accumulated.

## Evidence and References

Google's PlacesService callback returns a `PlacesServiceStatus`. `ZERO_RESULTS` means no result was found for that request, while `UNKNOWN_ERROR` is the server-error case that may succeed if retried. This PR handles those statuses differently instead of treating every non-OK as a reason to wait.

- https://developers.google.com/maps/documentation/javascript/reference/places-service#PlacesServiceStatus
- https://developers.google.com/maps/documentation/javascript/legacy/places
- https://react.dev/learn/synchronizing-with-effects

## Validation

Static checks:

```text
corepack yarn lint
corepack yarn build
```

Runtime measurement used Chrome with host resolver mapping `randomplacesjapan.netlify.app -> 127.0.0.1`, because the Google API key rejects plain `127.0.0.1` referers.

Baseline `origin/main`, 8 Go cycles:

```text
initial_ready: 4305ms
Go samples: 1304, 2507, 52037, 27257, 13713, 2513, 2523, 2455ms
max: 52037ms
```

This branch, 12 Go cycles:

```text
initial_ready: 1910ms
Go samples: 933, 337, 219, 302, 339, 211, 465, 332, 308, 222, 685, 322ms
median: 332ms
max: 933ms
```

## Follow-up

Google now warns that `google.maps.places.PlacesService` is deprecated for new customers as of 2025-03-01 and recommends `Place`. This PR keeps the current API for a minimal latency fix; migration to Places API New should be a separate change.
