### PR TITLE
feat: mobile UX rework + URL sharing + responsive desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,7 +17,10 @@
     </script>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/src/asset/icon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,109 +1,155 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { StreetView } from "./StreetView";
 import { PLACE_ICON, PLACE_LABEL, PlaceType } from "./type";
 import { useRandomPlace } from "./useRandomPlace";
 import { useJapanGeoJson } from "./useJapanGeoJson";
+import { BottomSheet } from "./components/BottomSheet";
+import { SegmentedControl } from "./components/SegmentedControl";
+import { PrefectureCombobox } from "./components/PrefectureCombobox";
+import { GoFab } from "./components/GoFab";
+import { readStateFromUrl, writeStateToUrl } from "./util/urlState";
+
+const PLACE_OPTIONS = [
+  {
+    value: "convenience_store" as const,
+    label: "Convenience",
+    icon: PLACE_ICON.convenience_store,
+  },
+  {
+    value: "train_station" as const,
+    label: "Train",
+    icon: PLACE_ICON.train_station,
+  },
+  {
+    value: "starbucks" as const,
+    label: "Starbucks",
+    icon: PLACE_ICON.starbucks,
+  },
+] as const;
 
 function App() {
-  const [placeType, setPlaceType] = useState<PlaceType>("convenience_store");
-  const [selected, setSelected] = useState("All Prefecture");
-  const [index, setIndex] = useState(-1);
+  const initialUrlState = useMemo(() => readStateFromUrl(), []);
+  const [placeType, setPlaceType] = useState<PlaceType>(
+    initialUrlState.placeType ?? "convenience_store"
+  );
+  const [selected, setSelected] = useState(
+    initialUrlState.prefecture ?? "All Prefecture"
+  );
+  const [sheetExpanded, setSheetExpanded] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
 
   const { data: jpGeoJson, isLoaded } = useJapanGeoJson();
 
-  useEffect(() => {
-    if (!jpGeoJson) return;
-    if (selected === "All Prefecture") {
-      setIndex(-1);
-      return;
-    }
-
-    const newIndex = jpGeoJson.features.findIndex(
-      (f) => f.properties?.nam === selected
-    );
-    setIndex(newIndex);
-  }, [selected, jpGeoJson]);
-
-  const { location, isLoading, refresh } = useRandomPlace(placeType, index);
+  const { location, isLoading, refresh } = useRandomPlace(
+    placeType,
+    selected,
+    initialUrlState.location
+  );
 
   const disabled = !isLoaded || isLoading;
 
-  return (
-    <div className="flex flex-col h-[100vh]">
-      <div className="top-0 z-50 absolute w-[100vw] bg-cream border-b border-black/10 flex flex-col items-start gap-[14px] px-[28px] py-[22px] text-neutral-900">
-        <div
-          className="absolute top-[18px] right-[28px] border-2 border-vermillion text-vermillion px-[10px] py-[6px] rounded-[2px] font-serif font-bold text-[10px] tracking-[2px] rotate-[-6deg] select-none"
-          aria-hidden="true"
-        >
-          JAPAN EXPLORE
-        </div>
-        <div className="flex flex-col gap-[2px]">
-          <div
-            className="font-serif text-[13px] text-vermillion tracking-[3px] mb-[2px]"
-            aria-hidden="true"
-          >
-            日本各地をランダム探索
-          </div>
-          <h1 className="font-serif font-bold text-[28px] leading-tight tracking-tight">
-            Random Places in <span className="text-vermillion">Japan</span>
-          </h1>
-          <span className="text-[13px] text-neutral-600">
-            Let's explore random places in japan. Choose place type and hit Go!
-          </span>
-        </div>
-        <div className="flex flex-row items-center justify-start gap-[8px] flex-wrap w-full">
-          {Object.entries(PLACE_LABEL).map(([key, label]) => (
-            <button
-              key={key}
-              className={`px-[14px] py-[8px] text-[13px] font-medium rounded-sm border transition-colors flex items-center gap-[6px] ${
-                key === placeType
-                  ? "bg-neutral-900 text-white border-neutral-900"
-                  : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-500"
-              }`}
-              onClick={() => setPlaceType(key as PlaceType)}
-            >
-              <span className="text-[14px]" aria-hidden="true">
-                {PLACE_ICON[key as PlaceType]}
-              </span>
-              {label}
-            </button>
-          ))}
+  useEffect(() => {
+    writeStateToUrl({ placeType, prefecture: selected, location });
+  }, [placeType, selected, location]);
 
-          <select
-            value={selected}
-            onChange={(e) => setSelected(e.target.value)}
-            className="bg-white text-neutral-800 border border-neutral-300 rounded-sm px-[14px] py-[8px] text-[13px] disabled:opacity-60"
-            disabled={!isLoaded}
-          >
-            <option value="All Prefecture">All Prefecture</option>
-            {jpGeoJson?.features.map((f) => {
-              const name = f.properties?.nam as string | undefined;
-              if (!name) return null;
-              return (
-                <option value={name} key={name}>
-                  {name}
-                </option>
-              );
-            })}
-          </select>
-          <button
-            className={`ml-auto rounded-sm px-[22px] py-[10px] text-[13px] font-semibold tracking-wider text-white transition-transform ${
-              disabled
-                ? "bg-neutral-400 shadow-none"
-                : "bg-vermillion shadow-[3px_3px_0_#1a1a1a] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[2px_2px_0_#1a1a1a]"
-            }`}
-            onClick={refresh}
-            disabled={disabled}
-          >
-            {!isLoaded
-              ? "Loading map data..."
-              : isLoading
-              ? "Loading..."
-              : "➡️ Go!"}
-          </button>
+  useEffect(() => {
+    if (!toast) return;
+    const id = window.setTimeout(() => setToast(null), 2000);
+    return () => window.clearTimeout(id);
+  }, [toast]);
+
+  const share = async () => {
+    const url = window.location.href;
+    if (navigator.share) {
+      try {
+        await navigator.share({ title: "Random Places in Japan", url });
+        return;
+      } catch {
+        // User dismissed the share sheet — fall through to clipboard copy.
+      }
+    }
+    try {
+      await navigator.clipboard.writeText(url);
+      setToast("Link copied");
+    } catch {
+      setToast("Copy failed");
+    }
+  };
+
+  const statusMessage = isLoading
+    ? "Loading new location…"
+    : location
+    ? `Showing ${PLACE_LABEL[placeType]}${
+        selected !== "All Prefecture" ? ` in ${selected}` : ""
+      }`
+    : "";
+
+  return (
+    <div className="relative h-[100dvh] w-[100vw] overflow-hidden bg-neutral-900">
+      <StreetView location={location} className="absolute inset-0" />
+
+      {isLoading && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-0 bg-black/40 flex items-center justify-center pointer-events-none"
+        >
+          <span className="w-10 h-10 rounded-full border-4 border-white/30 border-t-white animate-spin" />
         </div>
+      )}
+
+      <div role="status" aria-live="polite" className="sr-only">
+        {statusMessage}
       </div>
-      <StreetView location={location} />
+
+      <GoFab onClick={refresh} disabled={disabled} isLoading={isLoading} />
+
+      <BottomSheet
+        expanded={sheetExpanded}
+        onToggleExpanded={() => setSheetExpanded((v) => !v)}
+        peek={
+          <>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-800">
+              <span aria-hidden="true">{PLACE_ICON[placeType]}</span>
+              {PLACE_LABEL[placeType]}
+            </span>
+            <span className="inline-flex items-center gap-1 rounded-full bg-white border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-800">
+              <span aria-hidden="true">📍</span>
+              {selected}
+            </span>
+          </>
+        }
+      >
+        <SegmentedControl
+          label="Place type"
+          value={placeType}
+          onChange={setPlaceType}
+          options={PLACE_OPTIONS}
+        />
+        <PrefectureCombobox
+          features={jpGeoJson?.features}
+          value={selected}
+          onChange={setSelected}
+          disabled={!isLoaded}
+        />
+        <button
+          type="button"
+          onClick={share}
+          disabled={!location}
+          className="self-start rounded-sm border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 hover:border-neutral-500 disabled:opacity-60"
+        >
+          Share this spot
+        </button>
+      </BottomSheet>
+
+      {toast && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-24 left-1/2 -translate-x-1/2 z-[70] bg-neutral-900 text-white text-sm px-4 py-2 rounded-full shadow-lg"
+        >
+          {toast}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -101,45 +101,125 @@ function App() {
         {statusMessage}
       </div>
 
-      <GoFab onClick={refresh} disabled={disabled} isLoading={isLoading} />
-
-      <BottomSheet
-        expanded={sheetExpanded}
-        onToggleExpanded={() => setSheetExpanded((v) => !v)}
-        peek={
-          <>
-            <span className="inline-flex items-center gap-1 rounded-full bg-white border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-800">
-              <span aria-hidden="true">{PLACE_ICON[placeType]}</span>
-              {PLACE_LABEL[placeType]}
-            </span>
-            <span className="inline-flex items-center gap-1 rounded-full bg-white border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-800">
-              <span aria-hidden="true">📍</span>
-              {selected}
-            </span>
-          </>
-        }
-      >
-        <SegmentedControl
-          label="Place type"
-          value={placeType}
-          onChange={setPlaceType}
-          options={PLACE_OPTIONS}
-        />
-        <PrefectureCombobox
-          features={jpGeoJson?.features}
-          value={selected}
-          onChange={setSelected}
-          disabled={!isLoaded}
-        />
-        <button
-          type="button"
-          onClick={share}
-          disabled={!location}
-          className="self-start rounded-sm border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 hover:border-neutral-500 disabled:opacity-60"
+      {/* Desktop chrome — md and above (guidebook header) */}
+      <header className="hidden md:flex top-0 z-50 absolute w-[100vw] bg-cream border-b border-black/10 flex-col items-start gap-[14px] px-[28px] py-[22px] text-neutral-900">
+        <div
+          className="absolute top-[18px] right-[28px] border-2 border-vermillion text-vermillion px-[10px] py-[6px] rounded-[2px] font-serif font-bold text-[10px] tracking-[2px] rotate-[-6deg] select-none"
+          aria-hidden="true"
         >
-          Share this spot
-        </button>
-      </BottomSheet>
+          JAPAN EXPLORE
+        </div>
+        <div className="flex flex-col gap-[2px]">
+          <div
+            className="font-serif text-[13px] text-vermillion tracking-[3px] mb-[2px]"
+            aria-hidden="true"
+          >
+            日本各地をランダム探索
+          </div>
+          <h1 className="font-serif font-bold text-[28px] leading-tight tracking-tight">
+            Random Places in <span className="text-vermillion">Japan</span>
+          </h1>
+          <span className="text-[13px] text-neutral-600">
+            Let's explore random places in japan. Choose place type and hit Go!
+          </span>
+        </div>
+        <div className="flex flex-row items-center justify-start gap-[8px] flex-wrap w-full">
+          {(Object.entries(PLACE_LABEL) as [PlaceType, string][]).map(
+            ([key, label]) => (
+              <button
+                key={key}
+                type="button"
+                className={`px-[14px] py-[8px] text-[13px] font-medium rounded-sm border transition-colors flex items-center gap-[6px] ${
+                  key === placeType
+                    ? "bg-neutral-900 text-white border-neutral-900"
+                    : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-500"
+                }`}
+                onClick={() => setPlaceType(key)}
+              >
+                <span className="text-[14px]" aria-hidden="true">
+                  {PLACE_ICON[key]}
+                </span>
+                {label}
+              </button>
+            )
+          )}
+          <PrefectureCombobox
+            features={jpGeoJson?.features}
+            value={selected}
+            onChange={setSelected}
+            disabled={!isLoaded}
+            variant="desktop"
+          />
+          <button
+            type="button"
+            className={`ml-auto rounded-sm px-[22px] py-[10px] text-[13px] font-semibold tracking-wider text-white transition-transform ${
+              disabled
+                ? "bg-neutral-400 shadow-none"
+                : "bg-vermillion shadow-[3px_3px_0_#1a1a1a] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[2px_2px_0_#1a1a1a]"
+            }`}
+            onClick={refresh}
+            disabled={disabled}
+          >
+            {!isLoaded
+              ? "Loading map data..."
+              : isLoading
+              ? "Loading..."
+              : "➡️ Go!"}
+          </button>
+          <button
+            type="button"
+            onClick={share}
+            disabled={!location}
+            className="rounded-sm border border-neutral-300 bg-white px-[14px] py-[8px] text-[13px] text-neutral-800 hover:border-neutral-500 disabled:opacity-60"
+          >
+            Share
+          </button>
+        </div>
+      </header>
+
+      {/* Mobile chrome — below md (BottomSheet + FAB) */}
+      <div className="md:hidden">
+        <GoFab onClick={refresh} disabled={disabled} isLoading={isLoading} />
+
+        <BottomSheet
+          expanded={sheetExpanded}
+          onToggleExpanded={() => setSheetExpanded((v) => !v)}
+          peek={
+            <>
+              <span className="inline-flex items-center gap-1 rounded-full bg-white border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-800">
+                <span aria-hidden="true">{PLACE_ICON[placeType]}</span>
+                {PLACE_LABEL[placeType]}
+              </span>
+              <span className="inline-flex items-center gap-1 rounded-full bg-white border border-neutral-300 px-3 py-1 text-xs font-medium text-neutral-800">
+                <span aria-hidden="true">📍</span>
+                {selected}
+              </span>
+            </>
+          }
+        >
+          <SegmentedControl
+            label="Place type"
+            value={placeType}
+            onChange={setPlaceType}
+            options={PLACE_OPTIONS}
+          />
+          <PrefectureCombobox
+            features={jpGeoJson?.features}
+            value={selected}
+            onChange={setSelected}
+            disabled={!isLoaded}
+            variant="mobile"
+          />
+          <button
+            type="button"
+            onClick={share}
+            disabled={!location}
+            className="self-start rounded-sm border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 hover:border-neutral-500 disabled:opacity-60"
+          >
+            Share this spot
+          </button>
+        </BottomSheet>
+      </div>
 
       {toast && (
         <div

--- a/src/StreetView.tsx
+++ b/src/StreetView.tsx
@@ -7,6 +7,7 @@ const MAX_HEADING_ATTEMPTS = 20;
 
 export function StreetView({
   location,
+  className,
   ...props
 }: {
   location: Location | undefined;
@@ -98,8 +99,8 @@ export function StreetView({
   }, [location, panorama]);
 
   return (
-    <div {...props}>
-      <div ref={streetViewRef} className="static"></div>
+    <div {...props} className={className}>
+      <div ref={streetViewRef} className="w-full h-full" />
     </div>
   );
 }

--- a/src/components/BottomSheet.tsx
+++ b/src/components/BottomSheet.tsx
@@ -1,0 +1,44 @@
+import { ReactNode } from "react";
+
+type Props = {
+  expanded: boolean;
+  onToggleExpanded: () => void;
+  peek: ReactNode;
+  children: ReactNode;
+};
+
+export function BottomSheet({
+  expanded,
+  onToggleExpanded,
+  peek,
+  children,
+}: Props) {
+  return (
+    <div className="fixed bottom-0 left-0 right-0 z-40 bg-cream border-t border-black/10 shadow-[0_-4px_12px_rgba(0,0,0,0.08)]">
+      <button
+        type="button"
+        onClick={onToggleExpanded}
+        aria-expanded={expanded}
+        aria-label={expanded ? "Collapse panel" : "Expand panel"}
+        className="w-full px-4 pt-2 pb-3 flex flex-col items-stretch gap-2 text-left"
+      >
+        <span
+          aria-hidden="true"
+          className="mx-auto w-10 h-1 rounded-full bg-neutral-300"
+        />
+        <div className="flex items-center gap-2 flex-wrap">{peek}</div>
+      </button>
+      <div
+        className={`grid transition-[grid-template-rows] duration-200 ease-out ${
+          expanded ? "grid-rows-[1fr]" : "grid-rows-[0fr]"
+        }`}
+      >
+        <div className="overflow-hidden">
+          <div className="px-4 pt-2 pb-[max(1rem,env(safe-area-inset-bottom))] flex flex-col gap-4 max-h-[70dvh] overflow-y-auto">
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/GoFab.tsx
+++ b/src/components/GoFab.tsx
@@ -13,7 +13,7 @@ export function GoFab({ onClick, disabled, isLoading }: Props) {
       aria-label={
         isLoading ? "Loading new location" : "Roll a new random place"
       }
-      className={`fixed right-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-50 w-14 h-14 rounded-full text-white flex items-center justify-center text-xl font-bold transition-transform ${
+      className={`fixed right-4 bottom-[calc(5.5rem+env(safe-area-inset-bottom))] z-50 w-14 h-14 rounded-full text-white flex items-center justify-center text-xl font-bold transition-transform ${
         disabled
           ? "bg-neutral-400 shadow-none"
           : "bg-vermillion shadow-[3px_3px_0_#1a1a1a] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[2px_2px_0_#1a1a1a]"

--- a/src/components/GoFab.tsx
+++ b/src/components/GoFab.tsx
@@ -1,0 +1,32 @@
+type Props = {
+  onClick: () => void;
+  disabled: boolean;
+  isLoading: boolean;
+};
+
+export function GoFab({ onClick, disabled, isLoading }: Props) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={
+        isLoading ? "Loading new location" : "Roll a new random place"
+      }
+      className={`fixed right-4 bottom-[max(1rem,env(safe-area-inset-bottom))] z-50 w-14 h-14 rounded-full text-white flex items-center justify-center text-xl font-bold transition-transform ${
+        disabled
+          ? "bg-neutral-400 shadow-none"
+          : "bg-vermillion shadow-[3px_3px_0_#1a1a1a] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[2px_2px_0_#1a1a1a]"
+      }`}
+    >
+      {isLoading ? (
+        <span
+          aria-hidden="true"
+          className="w-5 h-5 rounded-full border-2 border-white/40 border-t-white animate-spin"
+        />
+      ) : (
+        <span aria-hidden="true">➡️</span>
+      )}
+    </button>
+  );
+}

--- a/src/components/PrefectureCombobox.tsx
+++ b/src/components/PrefectureCombobox.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { Feature } from "geojson";
 import { PREFECTURE_REGION } from "../util/prefectureRegions";
 import { REGIONS, Region } from "../type";
@@ -85,13 +86,14 @@ export function PrefectureCombobox({
         </span>
       </button>
 
-      {open && (
-        <div
-          className="fixed inset-0 z-[60] bg-white flex flex-col"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Choose prefecture"
-        >
+      {open &&
+        createPortal(
+          <div
+            className="fixed inset-0 z-[60] bg-white flex flex-col"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Choose prefecture"
+          >
           <div className="flex items-center gap-2 px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-3 border-b border-neutral-200">
             <input
               ref={searchRef}
@@ -157,8 +159,9 @@ export function PrefectureCombobox({
               </p>
             )}
           </div>
-        </div>
-      )}
+        </div>,
+          document.body
+        )}
     </>
   );
 }

--- a/src/components/PrefectureCombobox.tsx
+++ b/src/components/PrefectureCombobox.tsx
@@ -9,6 +9,7 @@ type Props = {
   value: string;
   onChange: (v: string) => void;
   disabled?: boolean;
+  variant?: "mobile" | "desktop";
 };
 
 export function PrefectureCombobox({
@@ -16,10 +17,13 @@ export function PrefectureCombobox({
   value,
   onChange,
   disabled,
+  variant = "mobile",
 }: Props) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
   const searchRef = useRef<HTMLInputElement>(null);
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!open) {
@@ -38,6 +42,19 @@ export function PrefectureCombobox({
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
   }, [open]);
+
+  // Desktop popover: dismiss on outside click.
+  useEffect(() => {
+    if (!open || variant !== "desktop") return;
+    const onPointer = (e: MouseEvent) => {
+      const t = e.target as Node;
+      if (popoverRef.current?.contains(t)) return;
+      if (triggerRef.current?.contains(t)) return;
+      setOpen(false);
+    };
+    window.addEventListener("mousedown", onPointer);
+    return () => window.removeEventListener("mousedown", onPointer);
+  }, [open, variant]);
 
   const grouped = useMemo(() => {
     const buckets = REGIONS.reduce((acc, r) => {
@@ -71,13 +88,109 @@ export function PrefectureCombobox({
   const showAllEntry =
     query.trim() === "" || "all prefecture".includes(query.trim().toLowerCase());
 
+  const triggerClass =
+    variant === "desktop"
+      ? "bg-white text-neutral-800 border border-neutral-300 rounded-sm px-[14px] py-[8px] text-[13px] inline-flex items-center gap-2 hover:border-neutral-500 disabled:opacity-60"
+      : "inline-flex items-center gap-2 rounded-sm border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 disabled:opacity-60";
+
+  const list = (
+    <>
+      {showAllEntry && (
+        <button
+          type="button"
+          className={`w-full text-left px-4 py-3 text-sm border-b border-neutral-100 hover:bg-neutral-50 ${
+            value === "All Prefecture" ? "bg-neutral-100 font-medium" : ""
+          }`}
+          onClick={() => {
+            onChange("All Prefecture");
+            setOpen(false);
+          }}
+        >
+          All Prefecture
+        </button>
+      )}
+      {grouped.map((g) => (
+        <section key={g.region}>
+          <h3 className="sticky top-0 bg-neutral-100/95 backdrop-blur px-4 py-1.5 text-xs font-semibold text-neutral-700 uppercase tracking-wider">
+            {g.region}
+          </h3>
+          {g.items.map((it) => (
+            <button
+              type="button"
+              key={it.nam}
+              onClick={() => {
+                onChange(it.nam);
+                setOpen(false);
+              }}
+              className={`w-full text-left px-4 py-3 text-sm border-b border-neutral-100 hover:bg-neutral-50 ${
+                value === it.nam ? "bg-neutral-100 font-medium" : ""
+              }`}
+            >
+              <span>{it.nam}</span>
+              {it.namJa && (
+                <span className="ml-2 text-xs text-neutral-500">
+                  {it.namJa}
+                </span>
+              )}
+            </button>
+          ))}
+        </section>
+      ))}
+      {!showAllEntry && grouped.length === 0 && (
+        <p className="px-4 py-6 text-center text-sm text-neutral-500">
+          No matches.
+        </p>
+      )}
+    </>
+  );
+
+  if (variant === "desktop") {
+    return (
+      <div className="relative">
+        <button
+          ref={triggerRef}
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          disabled={disabled}
+          className={triggerClass}
+        >
+          <span aria-hidden="true">📍</span>
+          <span>{value}</span>
+          <span aria-hidden="true" className="text-neutral-400">
+            ▾
+          </span>
+        </button>
+        {open && (
+          <div
+            ref={popoverRef}
+            role="dialog"
+            aria-label="Choose prefecture"
+            className="absolute top-full left-0 mt-1 z-[60] w-[360px] max-h-[480px] flex flex-col bg-white border border-neutral-300 rounded-sm shadow-lg"
+          >
+            <div className="p-2 border-b border-neutral-200">
+              <input
+                ref={searchRef}
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search prefecture..."
+                className="w-full rounded-sm border border-neutral-300 px-3 py-2 text-sm"
+              />
+            </div>
+            <div className="flex-1 overflow-y-auto">{list}</div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
   return (
     <>
       <button
         type="button"
         onClick={() => setOpen(true)}
         disabled={disabled}
-        className="inline-flex items-center gap-2 rounded-sm border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 disabled:opacity-60"
+        className={triggerClass}
       >
         <span aria-hidden="true">📍</span>
         <span>{value}</span>
@@ -94,72 +207,27 @@ export function PrefectureCombobox({
             aria-modal="true"
             aria-label="Choose prefecture"
           >
-          <div className="flex items-center gap-2 px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-3 border-b border-neutral-200">
-            <input
-              ref={searchRef}
-              type="search"
-              value={query}
-              onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search prefecture..."
-              className="flex-1 rounded-md border border-neutral-300 px-3 py-2 text-sm"
-            />
-            <button
-              type="button"
-              className="text-sm text-neutral-600 px-2 py-2"
-              onClick={() => setOpen(false)}
-            >
-              Cancel
-            </button>
-          </div>
-          <div className="flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
-            {showAllEntry && (
+            <div className="flex items-center gap-2 px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-3 border-b border-neutral-200">
+              <input
+                ref={searchRef}
+                type="search"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="Search prefecture..."
+                className="flex-1 rounded-md border border-neutral-300 px-3 py-2 text-sm"
+              />
               <button
                 type="button"
-                className={`w-full text-left px-4 py-3 text-sm border-b border-neutral-100 hover:bg-neutral-50 ${
-                  value === "All Prefecture" ? "bg-neutral-100 font-medium" : ""
-                }`}
-                onClick={() => {
-                  onChange("All Prefecture");
-                  setOpen(false);
-                }}
+                className="text-sm text-neutral-600 px-2 py-2"
+                onClick={() => setOpen(false)}
               >
-                All Prefecture
+                Cancel
               </button>
-            )}
-            {grouped.map((g) => (
-              <section key={g.region}>
-                <h3 className="sticky top-0 bg-neutral-100/95 backdrop-blur px-4 py-1.5 text-xs font-semibold text-neutral-700 uppercase tracking-wider">
-                  {g.region}
-                </h3>
-                {g.items.map((it) => (
-                  <button
-                    type="button"
-                    key={it.nam}
-                    onClick={() => {
-                      onChange(it.nam);
-                      setOpen(false);
-                    }}
-                    className={`w-full text-left px-4 py-3 text-sm border-b border-neutral-100 hover:bg-neutral-50 ${
-                      value === it.nam ? "bg-neutral-100 font-medium" : ""
-                    }`}
-                  >
-                    <span>{it.nam}</span>
-                    {it.namJa && (
-                      <span className="ml-2 text-xs text-neutral-500">
-                        {it.namJa}
-                      </span>
-                    )}
-                  </button>
-                ))}
-              </section>
-            ))}
-            {!showAllEntry && grouped.length === 0 && (
-              <p className="px-4 py-6 text-center text-sm text-neutral-500">
-                No matches.
-              </p>
-            )}
-          </div>
-        </div>,
+            </div>
+            <div className="flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+              {list}
+            </div>
+          </div>,
           document.body
         )}
     </>

--- a/src/components/PrefectureCombobox.tsx
+++ b/src/components/PrefectureCombobox.tsx
@@ -1,0 +1,164 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { Feature } from "geojson";
+import { PREFECTURE_REGION } from "../util/prefectureRegions";
+import { REGIONS, Region } from "../type";
+
+type Props = {
+  features: Feature[] | undefined;
+  value: string;
+  onChange: (v: string) => void;
+  disabled?: boolean;
+};
+
+export function PrefectureCombobox({
+  features,
+  value,
+  onChange,
+  disabled,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) {
+      setQuery("");
+      return;
+    }
+    const id = window.setTimeout(() => searchRef.current?.focus(), 0);
+    return () => window.clearTimeout(id);
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open]);
+
+  const grouped = useMemo(() => {
+    const buckets = REGIONS.reduce((acc, r) => {
+      acc[r] = [];
+      return acc;
+    }, {} as Record<Region, { nam: string; namJa: string }[]>);
+
+    features?.forEach((f) => {
+      const nam = f.properties?.nam as string | undefined;
+      if (!nam) return;
+      const region = PREFECTURE_REGION[nam];
+      if (!region) return;
+
+      const namJa = (f.properties?.nam_ja as string | undefined) ?? "";
+      const q = query.trim().toLowerCase();
+      if (
+        q &&
+        !nam.toLowerCase().includes(q) &&
+        !namJa.toLowerCase().includes(q)
+      ) {
+        return;
+      }
+      buckets[region].push({ nam, namJa });
+    });
+
+    return REGIONS.map((r) => ({ region: r, items: buckets[r] })).filter(
+      (g) => g.items.length > 0
+    );
+  }, [features, query]);
+
+  const showAllEntry =
+    query.trim() === "" || "all prefecture".includes(query.trim().toLowerCase());
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        disabled={disabled}
+        className="inline-flex items-center gap-2 rounded-sm border border-neutral-300 bg-white px-3 py-2 text-sm text-neutral-800 disabled:opacity-60"
+      >
+        <span aria-hidden="true">📍</span>
+        <span>{value}</span>
+        <span aria-hidden="true" className="text-neutral-400">
+          ▾
+        </span>
+      </button>
+
+      {open && (
+        <div
+          className="fixed inset-0 z-[60] bg-white flex flex-col"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Choose prefecture"
+        >
+          <div className="flex items-center gap-2 px-4 pt-[max(0.75rem,env(safe-area-inset-top))] pb-3 border-b border-neutral-200">
+            <input
+              ref={searchRef}
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search prefecture..."
+              className="flex-1 rounded-md border border-neutral-300 px-3 py-2 text-sm"
+            />
+            <button
+              type="button"
+              className="text-sm text-neutral-600 px-2 py-2"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto pb-[env(safe-area-inset-bottom)]">
+            {showAllEntry && (
+              <button
+                type="button"
+                className={`w-full text-left px-4 py-3 text-sm border-b border-neutral-100 hover:bg-neutral-50 ${
+                  value === "All Prefecture" ? "bg-neutral-100 font-medium" : ""
+                }`}
+                onClick={() => {
+                  onChange("All Prefecture");
+                  setOpen(false);
+                }}
+              >
+                All Prefecture
+              </button>
+            )}
+            {grouped.map((g) => (
+              <section key={g.region}>
+                <h3 className="sticky top-0 bg-neutral-100/95 backdrop-blur px-4 py-1.5 text-xs font-semibold text-neutral-700 uppercase tracking-wider">
+                  {g.region}
+                </h3>
+                {g.items.map((it) => (
+                  <button
+                    type="button"
+                    key={it.nam}
+                    onClick={() => {
+                      onChange(it.nam);
+                      setOpen(false);
+                    }}
+                    className={`w-full text-left px-4 py-3 text-sm border-b border-neutral-100 hover:bg-neutral-50 ${
+                      value === it.nam ? "bg-neutral-100 font-medium" : ""
+                    }`}
+                  >
+                    <span>{it.nam}</span>
+                    {it.namJa && (
+                      <span className="ml-2 text-xs text-neutral-500">
+                        {it.namJa}
+                      </span>
+                    )}
+                  </button>
+                ))}
+              </section>
+            ))}
+            {!showAllEntry && grouped.length === 0 && (
+              <p className="px-4 py-6 text-center text-sm text-neutral-500">
+                No matches.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/PrefectureCombobox.tsx
+++ b/src/components/PrefectureCombobox.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
-import type { Feature } from "geojson";
+import * as d3 from "d3";
 import { PREFECTURE_REGION } from "../util/prefectureRegions";
 import { REGIONS, Region } from "../type";
 
 type Props = {
-  features: Feature[] | undefined;
+  features: d3.ExtendedFeature[] | undefined;
   value: string;
   onChange: (v: string) => void;
   disabled?: boolean;

--- a/src/components/SegmentedControl.tsx
+++ b/src/components/SegmentedControl.tsx
@@ -1,0 +1,63 @@
+type Option<T extends string> = {
+  value: T;
+  label: string;
+  icon?: string;
+};
+
+type Props<T extends string> = {
+  value: T;
+  onChange: (v: T) => void;
+  options: readonly Option<T>[];
+  label?: string;
+};
+
+export function SegmentedControl<T extends string>({
+  value,
+  onChange,
+  options,
+  label,
+}: Props<T>) {
+  const currentIndex = options.findIndex((o) => o.value === value);
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={label}
+      className="flex w-full rounded-full bg-neutral-200/60 p-1"
+      onKeyDown={(e) => {
+        if (e.key !== "ArrowLeft" && e.key !== "ArrowRight") return;
+        if (currentIndex < 0) return;
+        const dir = e.key === "ArrowRight" ? 1 : -1;
+        const next = (currentIndex + dir + options.length) % options.length;
+        onChange(options[next].value);
+        e.preventDefault();
+      }}
+    >
+      {options.map((o) => {
+        const active = o.value === value;
+        return (
+          <button
+            type="button"
+            key={o.value}
+            role="radio"
+            aria-checked={active}
+            tabIndex={active ? 0 : -1}
+            onClick={() => onChange(o.value)}
+            className={`flex-1 rounded-full py-2 text-sm font-medium flex items-center justify-center gap-1 transition-colors ${
+              active
+                ? "bg-white text-neutral-900 shadow-sm"
+                : "text-neutral-600 hover:text-neutral-800"
+            }`}
+          >
+            {o.icon && (
+              <span aria-hidden="true" className="text-base">
+                {o.icon}
+              </span>
+            )}
+            <span>{o.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/type.ts
+++ b/src/type.ts
@@ -16,3 +16,16 @@ export const PLACE_ICON: { [key in PlaceType]: string } = {
   train_station: "🚉",
   starbucks: "☕",
 } as const;
+
+export const REGIONS = [
+  "Hokkaido",
+  "Tohoku",
+  "Kanto",
+  "Chubu",
+  "Kinki",
+  "Chugoku",
+  "Shikoku",
+  "Kyushu",
+] as const;
+
+export type Region = (typeof REGIONS)[number];

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -41,13 +41,24 @@ function randomFeatureCoordinates(feature: d3.ExtendedFeature) {
   };
 }
 
-export function useRandomPlace(placeType: PlaceType, index: number) {
+export function useRandomPlace(
+  placeType: PlaceType,
+  index: number,
+  initialLocation?: Location
+) {
   const { data: jpGeoJson } = useJapanGeoJson();
-  const [storeLocation, setStoreLocation] = useState<Location | undefined>();
-  const [isLoading, setIsLoading] = useState(true);
+  const [storeLocation, setStoreLocation] = useState<Location | undefined>(
+    initialLocation
+  );
+  const [isLoading, setIsLoading] = useState(!initialLocation);
   const [isServiceReady, setIsServiceReady] = useState(false);
   const serviceRef = useRef<google.maps.places.PlacesService | null>(null);
   const requestIdRef = useRef(0);
+  // Suppress the auto-search on mount when we hydrate from a shared URL.
+  // The skip is released as soon as the user changes placeType/index or
+  // triggers refresh() explicitly.
+  const skipAutoSearchRef = useRef<boolean>(initialLocation !== undefined);
+  const lastInputsRef = useRef({ placeType, index });
 
   useEffect(() => {
     let cancelled = false;
@@ -250,14 +261,28 @@ export function useRandomPlace(placeType: PlaceType, index: number) {
   );
 
   const refresh = useCallback(() => {
+    skipAutoSearchRef.current = false;
     requestIdRef.current += 1;
     void runSearch(requestIdRef.current);
   }, [runSearch]);
 
   useEffect(() => {
+    const inputsChanged =
+      lastInputsRef.current.placeType !== placeType ||
+      lastInputsRef.current.index !== index;
+
+    if (inputsChanged) {
+      lastInputsRef.current = { placeType, index };
+      skipAutoSearchRef.current = false;
+    }
+
+    if (skipAutoSearchRef.current) {
+      return;
+    }
+
     requestIdRef.current += 1;
     void runSearch(requestIdRef.current);
-  }, [runSearch]);
+  }, [runSearch, placeType, index]);
 
   return {
     location: storeLocation,

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import * as d3 from "d3";
 import { PlaceType, Location } from "./type";
 import { sleep } from "./util/sleep";
@@ -43,7 +43,7 @@ function randomFeatureCoordinates(feature: d3.ExtendedFeature) {
 
 export function useRandomPlace(
   placeType: PlaceType,
-  index: number,
+  prefecture: string,
   initialLocation?: Location
 ) {
   const { data: jpGeoJson } = useJapanGeoJson();
@@ -55,10 +55,18 @@ export function useRandomPlace(
   const serviceRef = useRef<google.maps.places.PlacesService | null>(null);
   const requestIdRef = useRef(0);
   // Suppress the auto-search on mount when we hydrate from a shared URL.
-  // The skip is released as soon as the user changes placeType/index or
-  // triggers refresh() explicitly.
+  // Release happens only when placeType/prefecture change from the values
+  // captured at mount or when refresh() is called explicitly — the
+  // asynchronous resolution of `prefecture -> index` must not trip it.
   const skipAutoSearchRef = useRef<boolean>(initialLocation !== undefined);
-  const lastInputsRef = useRef({ placeType, index });
+  const lastInputsRef = useRef({ placeType, prefecture });
+
+  const index = useMemo(() => {
+    if (!jpGeoJson || prefecture === "All Prefecture") return -1;
+    return jpGeoJson.features.findIndex(
+      (f) => f.properties?.nam === prefecture
+    );
+  }, [jpGeoJson, prefecture]);
 
   useEffect(() => {
     let cancelled = false;
@@ -269,10 +277,10 @@ export function useRandomPlace(
   useEffect(() => {
     const inputsChanged =
       lastInputsRef.current.placeType !== placeType ||
-      lastInputsRef.current.index !== index;
+      lastInputsRef.current.prefecture !== prefecture;
 
     if (inputsChanged) {
-      lastInputsRef.current = { placeType, index };
+      lastInputsRef.current = { placeType, prefecture };
       skipAutoSearchRef.current = false;
     }
 
@@ -282,7 +290,7 @@ export function useRandomPlace(
 
     requestIdRef.current += 1;
     void runSearch(requestIdRef.current);
-  }, [runSearch, placeType, index]);
+  }, [runSearch, placeType, prefecture]);
 
   return {
     location: storeLocation,

--- a/src/util/prefectureRegions.ts
+++ b/src/util/prefectureRegions.ts
@@ -1,0 +1,60 @@
+import type { Region } from "../type";
+
+// Maps GeoJSON `properties.nam` values from public/japan.json to the eight
+// commonly used Japanese regions. Keys must match the source data exactly.
+export const PREFECTURE_REGION: Record<string, Region> = {
+  "Hokkai Do": "Hokkaido",
+
+  "Aomori Ken": "Tohoku",
+  "Iwate Ken": "Tohoku",
+  "Miyagi Ken": "Tohoku",
+  "Akita Ken": "Tohoku",
+  "Yamagata Ken": "Tohoku",
+  "Fukushima Ken": "Tohoku",
+
+  "Ibaraki Ken": "Kanto",
+  "Tochigi Ken": "Kanto",
+  "Gunma Ken": "Kanto",
+  "Saitama Ken": "Kanto",
+  "Chiba Ken": "Kanto",
+  "Tokyo To": "Kanto",
+  "Kanagawa Ken": "Kanto",
+
+  "Niigata Ken": "Chubu",
+  "Toyama Ken": "Chubu",
+  "Ishikawa Ken": "Chubu",
+  "Fukui Ken": "Chubu",
+  "Yamanashi Ken": "Chubu",
+  "Nagano Ken": "Chubu",
+  "Gifu Ken": "Chubu",
+  "Shizuoka Ken": "Chubu",
+  "Aichi Ken": "Chubu",
+
+  "Mie Ken": "Kinki",
+  "Shiga Ken": "Kinki",
+  "Kyoto Fu": "Kinki",
+  "Osaka Fu": "Kinki",
+  "Hyogo Ken": "Kinki",
+  "Nara Ken": "Kinki",
+  "Wakayama Ken": "Kinki",
+
+  "Tottori Ken": "Chugoku",
+  "Shimane Ken": "Chugoku",
+  "Okayama Ken": "Chugoku",
+  "Hiroshima Ken": "Chugoku",
+  "Yamaguchi Ken": "Chugoku",
+
+  "Tokushima Ken": "Shikoku",
+  "Kagawa Ken": "Shikoku",
+  "Ehime Ken": "Shikoku",
+  "Kochi Ken": "Shikoku",
+
+  "Fukuoka Ken": "Kyushu",
+  "Saga Ken": "Kyushu",
+  "Nagasaki Ken": "Kyushu",
+  "Kumamoto Ken": "Kyushu",
+  "Oita Ken": "Kyushu",
+  "Miyazaki Ken": "Kyushu",
+  "Kagoshima Ken": "Kyushu",
+  "Okinawa Ken": "Kyushu",
+};

--- a/src/util/urlState.ts
+++ b/src/util/urlState.ts
@@ -1,4 +1,5 @@
 import { PLACE_LABEL, Location, PlaceType } from "../type";
+import { PREFECTURE_REGION } from "./prefectureRegions";
 
 export type AppUrlState = {
   placeType?: PlaceType;
@@ -10,6 +11,10 @@ function isPlaceType(v: string): v is PlaceType {
   return Object.prototype.hasOwnProperty.call(PLACE_LABEL, v);
 }
 
+function isKnownPrefecture(v: string): boolean {
+  return Object.prototype.hasOwnProperty.call(PREFECTURE_REGION, v);
+}
+
 export function readStateFromUrl(): AppUrlState {
   if (typeof window === "undefined") return {};
 
@@ -19,8 +24,10 @@ export function readStateFromUrl(): AppUrlState {
   const cat = params.get("cat");
   if (cat && isPlaceType(cat)) state.placeType = cat;
 
+  // Drop unknown values so the displayed label cannot diverge from the
+  // searched region (unknown pref silently maps to nationwide via index=-1).
   const pref = params.get("pref");
-  if (pref) state.prefecture = pref;
+  if (pref && isKnownPrefecture(pref)) state.prefecture = pref;
 
   const loc = params.get("loc");
   if (loc) {

--- a/src/util/urlState.ts
+++ b/src/util/urlState.ts
@@ -1,0 +1,65 @@
+import { PLACE_LABEL, Location, PlaceType } from "../type";
+
+export type AppUrlState = {
+  placeType?: PlaceType;
+  prefecture?: string;
+  location?: Location;
+};
+
+function isPlaceType(v: string): v is PlaceType {
+  return Object.prototype.hasOwnProperty.call(PLACE_LABEL, v);
+}
+
+export function readStateFromUrl(): AppUrlState {
+  if (typeof window === "undefined") return {};
+
+  const params = new URLSearchParams(window.location.search);
+  const state: AppUrlState = {};
+
+  const cat = params.get("cat");
+  if (cat && isPlaceType(cat)) state.placeType = cat;
+
+  const pref = params.get("pref");
+  if (pref) state.prefecture = pref;
+
+  const loc = params.get("loc");
+  if (loc) {
+    const [latStr, lngStr] = loc.split(",");
+    const lat = Number(latStr);
+    const lng = Number(lngStr);
+    if (Number.isFinite(lat) && Number.isFinite(lng)) {
+      state.location = { lat, lng };
+    }
+  }
+
+  return state;
+}
+
+export function writeStateToUrl(s: AppUrlState): void {
+  if (typeof window === "undefined") return;
+
+  const url = new URL(window.location.href);
+  const params = url.searchParams;
+
+  if (s.placeType) params.set("cat", s.placeType);
+  else params.delete("cat");
+
+  if (s.prefecture && s.prefecture !== "All Prefecture") {
+    params.set("pref", s.prefecture);
+  } else {
+    params.delete("pref");
+  }
+
+  if (s.location) {
+    params.set(
+      "loc",
+      `${s.location.lat.toFixed(6)},${s.location.lng.toFixed(6)}`
+    );
+  } else {
+    params.delete("loc");
+  }
+
+  const query = params.toString();
+  const next = `${url.pathname}${query ? `?${query}` : ""}${url.hash}`;
+  window.history.replaceState(null, "", next);
+}


### PR DESCRIPTION
## Summary

- 모바일 P0 버그 수정(375px Go 버튼 클리핑, 30% 검은 공백, 카테고리 줄바꿈) — `md:` 미만에서 BottomSheet + FAB 패턴 도입
- URL 상태 동기화(`?cat=&pref=&loc=`) + Share 버튼(navigator.share / clipboard fallback) 추가 — 공유 링크로 동일 카테고리·현·좌표 복원. `pref` 값은 알려진 47개 도도부현으로만 허용해 라벨/검색 범위 불일치 방지
- Prefecture 선택 47-item native `<select>` → 지역(8 region) 그룹 + 검색 가능한 PrefectureCombobox로 교체
- 데스크탑(`md:` 이상)은 기존 가이드북 헤더(serif 타이틀 + JAPAN EXPLORE 스탬프 + Vermillion Go!) 유지. PrefectureCombobox는 데스크탑에서 anchored popover, 모바일에서 full-screen portal로 분기

## Why responsive split

데스크탑까지 모바일 패턴(BottomSheet+FAB)을 적용했더니 (a) 의도된 가이드북 브랜드가 사라지고 (b) NN/G·Material 모두 bottom sheet를 모바일 패턴으로 정의하며 (c) 동종 random Street View 사이트(MapCrunch, Globe Genie, RandomStreetView)가 모두 데스크탑에서 persistent top chrome을 사용해 — 데스크탑 레이아웃을 원복하고 모바일만 새 패턴 적용.

## Test plan

- [x] \`yarn lint && yarn build\` 통과
- [x] 데스크탑 1440x900 검증: 가이드북 헤더 + 카테고리 버튼 + Prefecture popover + Go!/Share 정상
- [x] 모바일 375x812 검증: BottomSheet peek/expanded + FAB + 풀블리드 Street View + 검은 공백 제거
- [x] URL 공유 라운드트립: \`?cat=train_station&pref=Osaka+Fu&loc=...\` 진입 시 동일 상태 복원, 즉시 새 검색 트리거 안 됨
- [x] 잘못된 \`?pref=BogusName\` 진입 시 파라미터를 떨어내고 \"All Prefecture\"로 폴백 (런타임 검증 완료)
- [x] iOS Safari 실기기에서 safe-area-inset(홈 인디케이터) 회피 확인
- [x] 키보드 전용: Tab/Enter/Esc로 PrefectureCombobox·SegmentedControl 조작