### PR TITLE
fix: 브라우저 뒤로/앞으로 가기 동작 복구

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { StreetView } from "./StreetView";
 import { PLACE_ICON, PLACE_LABEL, PlaceType } from "./type";
 import { useRandomPlace } from "./useRandomPlace";
@@ -40,7 +40,7 @@ function App() {
 
   const { data: jpGeoJson, isLoaded } = useJapanGeoJson();
 
-  const { location, isLoading, refresh } = useRandomPlace(
+  const { location, isLoading, refresh, hydrate } = useRandomPlace(
     placeType,
     selected,
     initialUrlState.location
@@ -48,9 +48,51 @@ function App() {
 
   const disabled = !isLoaded || isLoading;
 
+  const isInitialMount = useRef(true);
+  // Set when a user action (Go!/category/prefecture change) initiates a new
+  // navigation. The next URL write consumes it as a push; subsequent writes
+  // for the same navigation (search-result location update) replace in place.
+  const navIntentRef = useRef(false);
+
   useEffect(() => {
-    writeStateToUrl({ placeType, prefecture: selected, location });
+    const mode =
+      !isInitialMount.current && navIntentRef.current ? "push" : "replace";
+    navIntentRef.current = false;
+    isInitialMount.current = false;
+    writeStateToUrl({ placeType, prefecture: selected, location }, mode);
   }, [placeType, selected, location]);
+
+  useEffect(() => {
+    const onPopState = () => {
+      const s = readStateFromUrl();
+      const nextPlaceType = s.placeType ?? "convenience_store";
+      const nextPrefecture = s.prefecture ?? "All Prefecture";
+      setPlaceType(nextPlaceType);
+      setSelected(nextPrefecture);
+      hydrate({
+        placeType: nextPlaceType,
+        prefecture: nextPrefecture,
+        location: s.location,
+      });
+    };
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, [hydrate]);
+
+  const handlePlaceTypeChange = useCallback((v: PlaceType) => {
+    navIntentRef.current = true;
+    setPlaceType(v);
+  }, []);
+
+  const handlePrefectureChange = useCallback((v: string) => {
+    navIntentRef.current = true;
+    setSelected(v);
+  }, []);
+
+  const handleRefresh = useCallback(() => {
+    navIntentRef.current = true;
+    refresh();
+  }, [refresh]);
 
   useEffect(() => {
     if (!toast) return;
@@ -134,7 +176,7 @@ function App() {
                     ? "bg-neutral-900 text-white border-neutral-900"
                     : "bg-white text-neutral-800 border-neutral-300 hover:border-neutral-500"
                 }`}
-                onClick={() => setPlaceType(key)}
+                onClick={() => handlePlaceTypeChange(key)}
               >
                 <span className="text-[14px]" aria-hidden="true">
                   {PLACE_ICON[key]}
@@ -146,7 +188,7 @@ function App() {
           <PrefectureCombobox
             features={jpGeoJson?.features}
             value={selected}
-            onChange={setSelected}
+            onChange={handlePrefectureChange}
             disabled={!isLoaded}
             variant="desktop"
           />
@@ -157,7 +199,7 @@ function App() {
                 ? "bg-neutral-400 shadow-none"
                 : "bg-vermillion shadow-[3px_3px_0_#1a1a1a] hover:translate-x-[1px] hover:translate-y-[1px] hover:shadow-[2px_2px_0_#1a1a1a]"
             }`}
-            onClick={refresh}
+            onClick={handleRefresh}
             disabled={disabled}
           >
             {!isLoaded
@@ -179,7 +221,7 @@ function App() {
 
       {/* Mobile chrome — below md (BottomSheet + FAB) */}
       <div className="md:hidden">
-        <GoFab onClick={refresh} disabled={disabled} isLoading={isLoading} />
+        <GoFab onClick={handleRefresh} disabled={disabled} isLoading={isLoading} />
 
         <BottomSheet
           expanded={sheetExpanded}
@@ -200,13 +242,13 @@ function App() {
           <SegmentedControl
             label="Place type"
             value={placeType}
-            onChange={setPlaceType}
+            onChange={handlePlaceTypeChange}
             options={PLACE_OPTIONS}
           />
           <PrefectureCombobox
             features={jpGeoJson?.features}
             value={selected}
-            onChange={setSelected}
+            onChange={handlePrefectureChange}
             disabled={!isLoaded}
             variant="mobile"
           />

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -274,6 +274,22 @@ export function useRandomPlace(
     void runSearch(requestIdRef.current);
   }, [runSearch]);
 
+  const hydrate = useCallback(
+    (s: { placeType: PlaceType; prefecture: string; location?: Location }) => {
+      // Cancel any in-flight search and re-arm the skip guard so the next
+      // render — driven by browser back/forward — doesn't auto-search.
+      requestIdRef.current += 1;
+      lastInputsRef.current = {
+        placeType: s.placeType,
+        prefecture: s.prefecture,
+      };
+      skipAutoSearchRef.current = true;
+      setStoreLocation(s.location);
+      setIsLoading(false);
+    },
+    []
+  );
+
   useEffect(() => {
     const inputsChanged =
       lastInputsRef.current.placeType !== placeType ||
@@ -296,5 +312,6 @@ export function useRandomPlace(
     location: storeLocation,
     isLoading,
     refresh,
+    hydrate,
   };
 }

--- a/src/util/urlState.ts
+++ b/src/util/urlState.ts
@@ -42,7 +42,10 @@ export function readStateFromUrl(): AppUrlState {
   return state;
 }
 
-export function writeStateToUrl(s: AppUrlState): void {
+export function writeStateToUrl(
+  s: AppUrlState,
+  mode: "push" | "replace" = "replace"
+): void {
   if (typeof window === "undefined") return;
 
   const url = new URL(window.location.href);
@@ -68,5 +71,14 @@ export function writeStateToUrl(s: AppUrlState): void {
 
   const query = params.toString();
   const next = `${url.pathname}${query ? `?${query}` : ""}${url.hash}`;
-  window.history.replaceState(null, "", next);
+  // Skip when URL is already in the desired state — avoids polluting the
+  // history stack after popstate (browser already updated the URL).
+  const current = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (next === current) return;
+
+  if (mode === "push") {
+    window.history.pushState(null, "", next);
+  } else {
+    window.history.replaceState(null, "", next);
+  }
 }


### PR DESCRIPTION
## Summary
- URL 상태를 `replaceState`로만 갱신하던 탓에 히스토리 스택이 쌓이지 않았고, `popstate` 리스너 부재로 브라우저 back/forward 시 React state가 동기화되지 않던 문제를 수정.
- 사용자 액션(카테고리/현 변경, Go!)은 `pushState`로 새 엔트리를 만들고, 그 결과로 도착하는 검색 location은 같은 엔트리를 `replaceState`로 갱신해 "1액션 = 1엔트리" 모델을 보장.
- `popstate`에서 URL을 다시 읽어 `useRandomPlace.hydrate()`로 location까지 복원하면서 자동 재검색을 억제.

## 주요 변경
- `src/util/urlState.ts`: `writeStateToUrl(s, mode)` — `push`/`replace` 모드 인자 + 동일 URL no-op 가드.
- `src/useRandomPlace.ts`: `hydrate({ placeType, prefecture, location })` 노출 — 검색 취소·`lastInputsRef`/`skipAutoSearchRef` 재정렬·`storeLocation` 복원.
- `src/App.tsx`: `navIntentRef`로 사용자 액션 표시, 핸들러 래핑(`handlePlaceTypeChange` / `handlePrefectureChange` / `handleRefresh`), `popstate` 리스너 추가.

## Test plan
프리뷰에서 다음 시나리오를 수동 검증하여 모두 통과:

- [x] 초기 진입(`?cat=starbucks&pref=Tokyo+To&loc=...`) 시 URL의 카테고리/현/location이 모두 화면에 반영
- [x] Convenience 클릭 → 새 검색 결과 → 히스토리 +1 (push)
- [x] Train 클릭 → 새 검색 결과 → 히스토리 +1 (push)
- [x] back ×1 → 직전 navigation의 카테고리·location 복원 (`convenience, locB`)
- [x] back ×2 → 초기 진입 상태 복원 (`starbucks, locA`)
- [x] forward ×1 → 다시 직전 상태 복원, 추가 push 없음 (`history.length` 불변)
- [x] popstate가 트리거하는 자동 재검색 없음 (시나리오 동안 `len`이 4를 넘지 않음)
- [x] `yarn build`(tsc + vite) 통과
- [x] ESLint 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)