### PR TITLE
fix: drop place results outside Japan boundary

### DIFF
--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -103,6 +103,19 @@ export function useRandomPlace(
     return { lat, lng };
   }, [index, jpGeoJson]);
 
+  // textSearch (Starbucks) treats location/radius as a bias, not a hard filter,
+  // so prominent results outside Japan (e.g. Busan from a Fukuoka base point)
+  // can be returned. Verify result coords against the loaded prefecture polygons.
+  const isInJapanBounds = useCallback(
+    (point: [number, number]): boolean => {
+      if (!jpGeoJson) return false;
+      return jpGeoJson.features.some((f) =>
+        d3.geoContains(f as d3.ExtendedFeature, point)
+      );
+    },
+    [jpGeoJson]
+  );
+
   const searchNearBy = useCallback(
     (location: Location, radius: number, requestId: number) => {
       if (requestIdRef.current !== requestId || !serviceRef.current) {
@@ -248,10 +261,12 @@ export function useRandomPlace(
             if (!newStoreLocation) {
               continue;
             }
-            setStoreLocation({
-              lat: newStoreLocation.lat(),
-              lng: newStoreLocation.lng(),
-            });
+            const lat = newStoreLocation.lat();
+            const lng = newStoreLocation.lng();
+            if (!isInJapanBounds([lng, lat])) {
+              continue;
+            }
+            setStoreLocation({ lat, lng });
             setIsLoading(false);
             return;
           }
@@ -265,7 +280,7 @@ export function useRandomPlace(
       setStoreLocation(undefined);
       setIsLoading(false);
     },
-    [generateBaseLocation, isServiceReady, jpGeoJson, searchStore]
+    [generateBaseLocation, isInJapanBounds, isServiceReady, jpGeoJson, searchStore]
   );
 
   const refresh = useCallback(() => {

--- a/src/useRandomPlace.ts
+++ b/src/useRandomPlace.ts
@@ -289,6 +289,18 @@ export function useRandomPlace(
     void runSearch(requestIdRef.current);
   }, [runSearch]);
 
+  // A `loc=` shared before the boundary fix landed could point outside Japan
+  // (e.g. Busan). Once the geojson is loaded, drop such hydrated coords and
+  // trigger a fresh search instead of stranding the user on a foreign result.
+  useEffect(() => {
+    if (!jpGeoJson || !initialLocation || !skipAutoSearchRef.current) return;
+    if (isInJapanBounds([initialLocation.lng, initialLocation.lat])) return;
+    skipAutoSearchRef.current = false;
+    setStoreLocation(undefined);
+    requestIdRef.current += 1;
+    void runSearch(requestIdRef.current);
+  }, [initialLocation, isInJapanBounds, jpGeoJson, runSearch]);
+
   useEffect(() => {
     const inputsChanged =
       lastInputsRef.current.placeType !== placeType ||


### PR DESCRIPTION
## Summary

- Starbucks 카테고리 검색이 일본 밖(예: 부산) 매장을 반환하던 버그 수정
- `useRandomPlace`의 검색 결과 좌표를 `d3.geoContains` + 47-prefecture polygon으로 검증해, 일본 외 결과는 다음 base point로 스킵
- 동일 boundary 검증을 URL 하이드레이트(`?loc=`)에도 적용 — 이미 공유된 잘못된 링크로 진입하면 좌표를 버리고 새 검색을 트리거

## Why

Google Places `textSearch` (Starbucks 분기에서 사용)는 `location`/`radius`를 **bias로만** 취급하고 hard filter로 쓰지 않는다 — 공식 문서: *"prominent results from outside of the search radius may be included"*. 그 결과 base point가 일본 남서부(후쿠오카·야마구치)에서 뽑힐 때 부산의 Starbucks가 prominent 결과로 끼어들 수 있었음.

버그는 [536b476](https://github.com/kws1207/japan-konbini/commit/536b476) "Enhance search quality of starbucks" 에서 `nearbySearch` → `textSearch`로 전환하며 잠재 도입됐고, [#12](https://github.com/kws1207/japan-konbini/pull/12)의 URL 공유 기능이 잘못된 좌표를 공유 링크로 박제 가능하게 만들면서 표면화됐다.

## Approach

옵션 비교:
- A. **결과 좌표 boundary 검증** (이 PR) — textSearch의 매칭 정밀도 유지, 추가 API 호출 0, 이미 로드된 `jpGeoJson` 재사용
- B. `nearbySearch + keyword "Starbucks"`로 회귀 — radius hard filter지만 정밀도 ↓ (536b476이 떠난 이유)
- C. Places API (New) `searchText` + `locationRestriction` — 의존성·과금 모델 변경 필요

A를 채택. nearbySearch 결과(편의점·역)에도 동일 검증을 적용해 defense-in-depth. URL 하이드레이트 경로도 같은 게이트로 막아, fix 머지 이전에 살포된 잘못된 공유 링크도 자동으로 정상화됨.

## Test plan

- [x] `yarn lint && yarn build` 통과
- [x] HTTP 모드 vite로 Starbucks 9회 연속 검색 — 전부 일본 내 좌표 반환 (가나가와·효고·나가사키·오키나와·군마·니가타·후쿠이·사가·도쿄)
- [x] `d3.geoContains` 직접 호출로 부산(35.094,129.065)·서울 → `false`, 도쿄·후쿠오카·오사카·오키나와 → `true` 확인
- [x] 부산 URL `?cat=starbucks&loc=35.093779,129.065208` 진입 → 자동으로 `loc=36.0726,140.0852` (이바라키/츠쿠바)로 교체됨, Street View도 일본 내로 갱신
- [x] 도쿄 URL `?cat=starbucks&loc=35.6895,139.6917` 진입 → 3초간 좌표 그대로 유지, 자동 재검색 트리거 안 됨
- [x] 편의점 5회 검색 (야마나시·오카야마·도쿄·오키나와·도쿄) + 역 5회 검색 (고치·이바라키·오카야마·구마모토·아오모리) — 회귀 없음, 모두 일본 내 좌표